### PR TITLE
add code to search sheet metal parts for attributes

### DIFF
--- a/AVA_InvDWGAPI/InvExtensions.vb
+++ b/AVA_InvDWGAPI/InvExtensions.vb
@@ -87,7 +87,7 @@ Public Module InvExtensions
             CType(aView.ReferencedDocumentDescriptor.ReferencedDocument, Inventor.AssemblyDocument).ComponentDefinition.Occurrences.AllLeafOccurrences
 
                 'Fist see if there are faces that has the attibute
-                If aView.DrawingCurves(viewOCC).Count > 0 And viewOCC.Definition.Type = ObjectTypeEnum.kPartComponentDefinitionObject Then
+                If aView.DrawingCurves(viewOCC).Count > 0 And (viewOCC.Definition.Type = ObjectTypeEnum.kPartComponentDefinitionObject Or viewOCC.Definition.Type = ObjectTypeEnum.kSheetMetalComponentDefinitionObject) Then
 
                     Dim oCollection As Inventor.ObjectCollection = CType(viewOCC.Definition.Document,
                                     Inventor.PartDocument).AttributeManager.FindObjects(AttributeSetName,

--- a/KETIV_AVA_InvAPIProTips/InvExtensions.vb
+++ b/KETIV_AVA_InvAPIProTips/InvExtensions.vb
@@ -86,7 +86,7 @@ Public Module InvExtensions
             CType(aView.ReferencedDocumentDescriptor.ReferencedDocument, Inventor.AssemblyDocument).ComponentDefinition.Occurrences.AllLeafOccurrences
 
             'Fist see if there are faces that has the attibute
-            If aView.DrawingCurves(viewOCC).Count > 0 And viewOCC.Definition.Type = ObjectTypeEnum.kPartComponentDefinitionObject Then
+            If aView.DrawingCurves(viewOCC).Count > 0 And (viewOCC.Definition.Type = ObjectTypeEnum.kPartComponentDefinitionObject Or viewOCC.Definition.Type = ObjectTypeEnum.kSheetMetalComponentDefinitionObject) Then
 
                 Dim oCollection As Inventor.ObjectCollection = CType(viewOCC.Definition.Document,
                                     Inventor.PartDocument).AttributeManager.FindObjects(AttributeSetName,


### PR DESCRIPTION
I was using this code for some experimentation and discovered that the "findCurvesByAttribute" extension skipped over any "sheet metal" parts that are inside an assembly. This is because the object type enumerator is different for sheet metal parts than it is for regular parts. I added code to include sheet metal parts in the search as well.